### PR TITLE
Update factoredmarcher.cpp

### DIFF
--- a/eikonalfm/factoredmarcher.cpp
+++ b/eikonalfm/factoredmarcher.cpp
@@ -29,7 +29,7 @@ const long *FactoredMarcher::to_vector(unsigned long i)
 void FactoredMarcher::initialize(double *const tau0, double *const tau1, const unsigned long x_s, const long *const x_s_v)
 {
 	// iterating vector (see below)
-    unsigned long *x = new unsigned long[ndim];
+        long *x = new long[ndim];
 	for (int d = 0; d < ndim; d++)
 		x[d] = 0;
 


### PR DESCRIPTION
The line 43 has a problem:
distance += pow((double)((x[d] - x_s_v[d]) * dx[d]), 2);

Both x and x_s_v are unsigned. When the source is not at [0, 0], there is an overflow due to x[d] smaller than x_s_v[d] at some points and the distance becomes meaningless. This does not break the example:
c = np.ones((100, 100))
x_s = (1,1)
dx = (1.0, 1.0)
tau1_ffm = eikonalfm.factored_fast_marching(c, x_s, dx, order)

But if you scale the model, the solver will fail:
c = 1000*np.ones((100, 100))
x_s = (1,1)
dx = (0.001, 0.001)
tau1_ffm = eikonalfm.factored_fast_marching(c, x_s, dx, order)
"RuntimeError: Negative discriminant in solve_quadratic"