### PR TITLE
Use github CI to create wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,179 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Windows 32-bit
+          - os: windows-latest
+            python: 36
+            platform_id: win32
+          - os: windows-latest
+            python: 37
+            platform_id: win32
+          - os: windows-latest
+            python: 38
+            platform_id: win32
+          - os: windows-latest
+            python: 39
+            platform_id: win32
+          - os: windows-latest
+            python: 310
+            platform_id: win32
+          - os: windows-latest
+            python: 311
+            platform_id: win32
+
+          # Windows 64-bit
+          - os: windows-latest
+            python: 36
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 37
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 38
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+
+          # Linux 32-bit
+          - os: ubuntu-latest
+            python: 36
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 37
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_i686
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_i686
+
+          # Linux 64-bit
+          - os: ubuntu-latest
+            python: 36
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 37
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+
+          # macOS on Intel 64-bit
+          - os: macos-latest
+            python: 36
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 37
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 38
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 39
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 310
+            arch: x86_64
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 311
+            arch: x86_64
+            platform_id: macosx_x86_64
+
+          # macOS on Apple M1 64-bit
+          - os: macos-latest
+            python: 38
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 39
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 310
+            arch: arm64
+            platform_id: macosx_arm64
+          - os: macos-latest
+            python: 311
+            arch: arm64
+            platform_id: macosx_arm64
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v3
+        name: Install Python host for cibuildwheel
+        with:
+          python-version: '3.9'
+
+        # Visual Studio
+      - name: Set up MSVC x86
+        if: matrix.platform_id == 'win32'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+
+        # Visual Studio
+      - name: Set up MSVC x64
+        if: matrix.platform_id == 'win_amd64'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.11.4
+
+      - name: Build wheels
+        # to supply options, put them in 'env', like:
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+
+          # Include latest Python beta
+          CIBW_PRERELEASE_PYTHONS: True
+
+          CIBW_TEST_COMMAND: python -c "import eikonalfm"
+
+        run: python -m cibuildwheel --output-dir wheelhouse
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl


### PR DESCRIPTION
Hi,

This PR create a new action to create wheels using the Github CI. It uses [Cibuildwheel](https://github.com/pypa/cibuildwheel) and creates wheels to Windows (x86 and x86_64), Linux(x86 and x86_64) and MacOS (x86_64 and ARM64) from Python 3.6 to 3.11. For now it only creates the wheels. You can make it publish the wheels automatically using Github CI [this way](https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/#github-actions). To upload the wheels to Pypi by yourself you need to download the artifacts (in the GitHub tab Action, click in the last workflow run completed and look for the artifact in the bottom of the page) and use twine. 